### PR TITLE
timestamp value mismatched

### DIFF
--- a/sensor/views.py
+++ b/sensor/views.py
@@ -50,8 +50,8 @@ def post_ph_sensor_data(request):
                 ph_value_formatted = f'{ph_value:.4f}'
                 timestamp = datetime.now()
                 doc = {
-                        'ph_value': ph_value,
-                        'timestamp': ph_value_formatted
+                        'ph_value': ph_value_formatted,
+                        'timestamp': timestamp
                     }
             
                 


### PR DESCRIPTION
timestamp value is placed as ph_value
ObjectId('65fee9e1d3d07c6d81a8d930'), 'ph_value': 9.185791016, 'timestamp': '9.1858'}, {'_id': ObjectId('65fee9efd3d07c6d81a8d933'), 'ph_value': 8.658853531, 'timestamp': '8.6589'}]